### PR TITLE
Install OpenShift from a local build

### DIFF
--- a/inventory/aws/ec2.py
+++ b/inventory/aws/ec2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 EC2 external inventory script

--- a/inventory/gce/gce.py
+++ b/inventory/gce/gce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/inventory/multi_ec2.py
+++ b/inventory/multi_ec2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from time import time
 import argparse

--- a/lib/aws_command.rb
+++ b/lib/aws_command.rb
@@ -40,6 +40,13 @@ module OpenShift
         ah.extra_vars['oo_new_inst_tags'].merge!(AwsHelper.generate_host_type_tag(options[:type]))
         ah.extra_vars['oo_new_inst_tags'].merge!(AwsHelper.generate_env_host_type_tag(options[:env], options[:type]))
 
+        # Check if we install a custom openshift
+        if !ENV['OO_OPENSHIFT_BINARY'].nil?
+          ah.extra_vars['oo_openshift_binary'] = ENV['OO_OPENSHIFT_BINARY']
+          FileUtils.cp(ENV['OO_OPENSHIFT_BINARY'], 'roles/openshift_master/files')
+          FileUtils.cp(ENV['OO_OPENSHIFT_BINARY'], 'roles/openshift_minion/files')
+        end
+
         puts
         puts "Creating #{options[:count]} #{options[:type]} instance(s) in AWS..."
         ah.ignore_bug_6407

--- a/playbooks/aws/openshift-master/launch.yml
+++ b/playbooks/aws/openshift-master/launch.yml
@@ -7,7 +7,7 @@
 
   vars:
     inst_region: us-east-1
-    atomic_ami: ami-86781fee
+    atomic_ami: ami-d2ee9fba
     user_data_file: user_data.txt
 
   vars_files:
@@ -18,9 +18,9 @@
       ec2:
         state: present
         region: "{{ inst_region }}"
-        keypair: libra
+        keypair: lenaic@ncelhuard-Xperiment
         group: ['public']
-        instance_type: m3.large
+        instance_type: t2.micro
         image: "{{ atomic_ami }}"
         count: "{{ oo_new_inst_names | oo_len }}"
         user_data: "{{ lookup('file', user_data_file) }}"

--- a/playbooks/aws/openshift-minion/launch.yml
+++ b/playbooks/aws/openshift-minion/launch.yml
@@ -7,7 +7,7 @@
 
   vars:
     inst_region: us-east-1
-    atomic_ami: ami-86781fee
+    atomic_ami: ami-d2ee9fba
     user_data_file: user_data.txt
 
   vars_files:
@@ -18,9 +18,9 @@
       ec2:
         state: present
         region: "{{ inst_region }}"
-        keypair: libra
+        keypair: lenaic@ncelhuard-Xperiment
         group: ['public']
-        instance_type: m3.large
+        instance_type: t2.micro
         image: "{{ atomic_ami }}"
         count: "{{ oo_new_inst_names | oo_len }}"
         user_data: "{{ lookup('file', user_data_file) }}"

--- a/roles/openshift_master/files/.gitignore
+++ b/roles/openshift_master/files/.gitignore
@@ -1,0 +1,1 @@
+/openshift

--- a/roles/openshift_master/files/openshift.service
+++ b/roles/openshift_master/files/openshift.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenShift
+After=docker.service
+Requires=docker.service
+Documentation=https://github.com/openshift/origin
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/openshift
+ExecStart=/usr/local/bin/openshift start $ROLE $OPTIONS
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -1,22 +1,18 @@
 ---
 # tasks file for openshift_master
-- name: Install Origin
-  yum: pkg=origin state=installed
 
   # fixme: Once openshift stops resolving hostnames for minion queries remove this...
 - name: Set hostname to IP Addr (WORKAROUND)
   hostname: name={{ oo_bind_ip }}
 
-- name: Configure OpenShift Master settings
-  lineinfile: >
-    dest=/etc/sysconfig/openshift
-    regexp={{ item.regex }}
-    line="{{ item.line }}"
-  with_items:
-    - { regex: '^ROLE=', line: 'ROLE=\"master\"' }
-    - { regex: '^OPTIONS=', line: 'OPTIONS=\"--nodes={{ oo_minion_ips | join(",") }}  --loglevel=5\"' }
-  notify:
-    - restart openshift-master
+- name: Install docker
+  yum: pkg=docker state=installed
+
+- include: openshift_from_yum.yml
+  when: oo_openshift_binary is not defined
+
+- include: openshift_from_local.yml
+  when: oo_openshift_binary is defined
 
 - name: Open firewalld port for etcd embedded in OpenShift
   firewalld: port=4001/tcp permanent=false state=enabled

--- a/roles/openshift_master/tasks/openshift_from_local.yml
+++ b/roles/openshift_master/tasks/openshift_from_local.yml
@@ -1,0 +1,17 @@
+- name: Copy OpenShift binary
+  copy:
+    src: openshift
+    dest: /usr/local/bin/openshift
+    mode: 0755
+
+- name: Configure OpenShift Master settings
+  template:
+    src: sysconfig_openshift
+    dest: /etc/sysconfig/openshift
+    mode: 0644
+    owner: root
+    group: root
+  notify: restart openshift-master
+
+- name: Configure OpenShift systemd unit
+  copy: src=openshift.service dest=/etc/systemd/system/openshift.service

--- a/roles/openshift_master/tasks/openshift_from_yum.yml
+++ b/roles/openshift_master/tasks/openshift_from_yum.yml
@@ -1,0 +1,13 @@
+- name: Install Origin
+  yum: pkg=origin state=installed
+
+- name: Configure OpenShift Master settings
+  lineinfile: >
+    dest=/etc/sysconfig/openshift
+    regexp={{ item.regex }}
+    line="{{ item.line }}"
+  with_items:
+    - { regex: '^ROLE=', line: 'ROLE=\"master\"' }
+    - { regex: '^OPTIONS=', line: 'OPTIONS=\"--nodes={{ oo_minion_ips | join(",") }}  --loglevel=5\"' }
+  notify:
+    - restart openshift-master

--- a/roles/openshift_master/templates/sysconfig_openshift
+++ b/roles/openshift_master/templates/sysconfig_openshift
@@ -1,0 +1,2 @@
+ROLE="master"
+OPTIONS="--nodes={{ oo_minion_ips | join(",") }}  --loglevel=5"

--- a/roles/openshift_minion/files/.gitignore
+++ b/roles/openshift_minion/files/.gitignore
@@ -1,0 +1,1 @@
+/openshift

--- a/roles/openshift_minion/files/openshift.service
+++ b/roles/openshift_minion/files/openshift.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenShift
+After=docker.service
+Requires=docker.service
+Documentation=https://github.com/openshift/origin
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/openshift
+ExecStart=/usr/local/bin/openshift start $ROLE $OPTIONS
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/openshift_minion/tasks/main.yml
+++ b/roles/openshift_minion/tasks/main.yml
@@ -1,22 +1,18 @@
 ---
 # tasks file for openshift_minion
-- name: Install OpenShift
-  yum: pkg=origin state=installed
 
   # fixme: Once openshift stops resolving hostnames for minion queries remove this...
 - name: Set hostname to IP Addr (WORKAROUND)
   hostname: name={{ oo_bind_ip }}
 
-- name: Configure OpenShift Minion settings
-  lineinfile: >
-    dest=/etc/sysconfig/openshift
-    regexp={{ item.regex }}
-    line="{{ item.line }}"
-  with_items:
-    - { regex: '^ROLE=', line: 'ROLE=\"node\"' }
-    - { regex: '^OPTIONS=', line: 'OPTIONS=\"--master=http://{{ oo_master_ips[0] }}:8080  --loglevel=5\"' }
-  notify:
-    - restart openshift-minion
+- name: Install docker
+  yum: pkg=docker state=installed
+
+- include: openshift_from_yum.yml
+  when: oo_openshift_binary is not defined
+
+- include: openshift_from_local.yml
+  when: oo_openshift_binary is defined
 
 - name: Open firewalld port for OpenShift
   firewalld: port=10250/tcp permanent=false state=enabled

--- a/roles/openshift_minion/tasks/openshift_from_local.yml
+++ b/roles/openshift_minion/tasks/openshift_from_local.yml
@@ -1,0 +1,18 @@
+- name: Copy OpenShift binary
+  copy:
+    src: openshift
+    dest: /usr/local/bin/openshift
+    mode: 0755
+
+- name: Configure OpenShift Minion settings
+  template:
+    src: sysconfig_openshift
+    dest: /etc/sysconfig/openshift
+    mode: 0644
+    owner: root
+    group: root
+  notify: restart openshift-minion
+
+- name: Configure OpenShift systemd unit
+  copy: src=openshift.service dest=/etc/systemd/system/openshift.service
+

--- a/roles/openshift_minion/tasks/openshift_from_yum.yml
+++ b/roles/openshift_minion/tasks/openshift_from_yum.yml
@@ -1,0 +1,13 @@
+- name: Install Origin
+  yum: pkg=origin state=installed
+
+- name: Configure OpenShift Minion settings
+  lineinfile: >
+    dest=/etc/sysconfig/openshift
+    regexp={{ item.regex }}
+    line="{{ item.line }}"
+  with_items:
+    - { regex: '^ROLE=', line: 'ROLE=\"node\"' }
+    - { regex: '^OPTIONS=', line: 'OPTIONS=\"--master=http://{{ oo_master_ips[0] }}:8080  --loglevel=5\"' }
+  notify:
+    - restart openshift-minion

--- a/roles/openshift_minion/templates/sysconfig_openshift
+++ b/roles/openshift_minion/templates/sysconfig_openshift
@@ -1,0 +1,2 @@
+ROLE="node"
+OPTIONS="--master=http://{{ oo_master_ips[0] }}:8080  --loglevel=5"

--- a/test/units/mutli_ec2_test.py
+++ b/test/units/mutli_ec2_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import unittest
 import sys


### PR DESCRIPTION
Hi Akram,
With commit e54a052, if the environment variable OO_OPENSHIFT_BINARY is set, then, it must be the openshift binary that will be deployed. If it is not set, then OpenShift will be installed from the yum repo