### PR TITLE
Make the AWS region, AMI, keypair and instance type customisable

### DIFF
--- a/cluster.sh
+++ b/cluster.sh
@@ -3,6 +3,9 @@
 MINIONS=3
 MASTERS=1
 
+# Read the config file
+source "$(dirname $0)/config"
+
 # If the environment variable OO_PROVDER is defined, it used for the provider
 PROVIDER=${OO_PROVIDER:-''}
 # Otherwise, default is gce (Google Compute Engine)

--- a/config
+++ b/config
@@ -1,0 +1,66 @@
+####################
+# General settings #
+####################
+
+# OO_PROVIDER
+#
+# Selects the cloud provider to use
+# Choices: gce, aws
+# Default: gce
+
+#export OO_PROVIDER=aws
+
+################
+# GCE settings #
+################
+
+################
+# AWS settings #
+################
+
+# Credentials
+#
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+#source ~/aws-credentials
+#export AWS_ACCESS_KEY_ID
+#export AWS_SECRET_ACCESS_KEY
+
+# OO_OPENSHIFT_BINARY
+#
+# Path of a locally built openshift binary
+#
+# If this variable is set, then, the locally built openshift will be installed
+# in /usr/local/bin on the AWS machines.
+# If this variable is not set, then, openshift will be installed from the yum repository
+
+#export OO_OPENSHIFT_BINARY=$HOME/doc/prog/RedHat/origin/_output/local/go/bin/openshift
+
+# OO_AWS_REGION
+#
+# Selects an AWS region
+# Default: us-east-1
+
+#export OO_AWS_REGION=us-east-1
+
+# OO_AWS_AMI
+#
+# AWS image to use to create the VMs
+# Default: ami-86781fee
+
+#export OO_AWS_AMI=ami-d2ee9fba
+
+# OO_AWS_KEYPAIR
+#
+# keypair to use for new VMs
+# Default: libra
+
+#export OO_AWS_KEYPAIR=lenaic@ncelhuard-Xperiment
+
+# OO_AWS_INSTANCE_TYPE
+#
+# Instance type of new VMs
+# Default: m3.large
+
+#export OO_AWS_INSTANCE_TYPE=t2.micro

--- a/lib/aws_command.rb
+++ b/lib/aws_command.rb
@@ -47,6 +47,12 @@ module OpenShift
           FileUtils.cp(ENV['OO_OPENSHIFT_BINARY'], 'roles/openshift_minion/files')
         end
 
+        # Check AWS settings override
+        ah.extra_vars['oo_aws_region']  = ENV['OO_AWS_REGION']  if !ENV['OO_AWS_REGION'].nil?
+        ah.extra_vars['oo_aws_ami']     = ENV['OO_AWS_AMI']     if !ENV['OO_AWS_AMI'].nil?
+        ah.extra_vars['oo_aws_keypair'] = ENV['OO_AWS_KEYPAIR'] if !ENV['OO_AWS_KEYPAIR'].nil?
+        ah.extra_vars['oo_aws_instance_type'] = ENV['OO_AWS_INSTANCE_TYPE'] if !ENV['OO_AWS_INSTANCE_TYPE'].nil?
+
         puts
         puts "Creating #{options[:count]} #{options[:type]} instance(s) in AWS..."
         ah.ignore_bug_6407
@@ -94,6 +100,13 @@ module OpenShift
           host_type = options[:type]
         else
           abort 'Error: you need to specify either --name or (--type and --env)'
+        end
+
+        # Check if we install a custom openshift
+        if !ENV['OO_OPENSHIFT_BINARY'].nil?
+          ah.extra_vars['oo_openshift_binary'] = ENV['OO_OPENSHIFT_BINARY']
+          FileUtils.cp(ENV['OO_OPENSHIFT_BINARY'], 'roles/openshift_master/files')
+          FileUtils.cp(ENV['OO_OPENSHIFT_BINARY'], 'roles/openshift_minion/files')
         end
 
         puts

--- a/playbooks/aws/openshift-master/launch.yml
+++ b/playbooks/aws/openshift-master/launch.yml
@@ -6,8 +6,7 @@
   accelerate: false
 
   vars:
-    inst_region: us-east-1
-    atomic_ami: ami-d2ee9fba
+    inst_region: "{{ oo_aws_region | default('us-east-1') }}"
     user_data_file: user_data.txt
 
   vars_files:
@@ -18,10 +17,10 @@
       ec2:
         state: present
         region: "{{ inst_region }}"
-        keypair: lenaic@ncelhuard-Xperiment
+        keypair: "{{ oo_aws_keypair | default('libra') }}"
         group: ['public']
-        instance_type: t2.micro
-        image: "{{ atomic_ami }}"
+        instance_type: "{{ oo_aws_instance_type | default('m3.large') }}"
+        image: "{{ oo_aws_ami | default('ami-86781fee') }}"
         count: "{{ oo_new_inst_names | oo_len }}"
         user_data: "{{ lookup('file', user_data_file) }}"
         wait: yes

--- a/playbooks/aws/openshift-minion/launch.yml
+++ b/playbooks/aws/openshift-minion/launch.yml
@@ -6,8 +6,7 @@
   accelerate: false
 
   vars:
-    inst_region: us-east-1
-    atomic_ami: ami-d2ee9fba
+    inst_region: "{{ oo_aws_region | default('us-east-1') }}"
     user_data_file: user_data.txt
 
   vars_files:
@@ -18,10 +17,10 @@
       ec2:
         state: present
         region: "{{ inst_region }}"
-        keypair: lenaic@ncelhuard-Xperiment
+        keypair: "{{ oo_aws_keypair | default('libra') }}"
         group: ['public']
-        instance_type: t2.micro
-        image: "{{ atomic_ami }}"
+        instance_type: "{{ oo_aws_instance_type | default('m3.large') }}"
+        image: "{{ oo_aws_ami | default('ami-86781fee') }}"
         count: "{{ oo_new_inst_names | oo_len }}"
         user_data: "{{ lookup('file', user_data_file) }}"
         wait: yes

--- a/roles/openshift_master/files/openshift.service
+++ b/roles/openshift_master/files/openshift.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=OpenShift
-After=docker.service
-Requires=docker.service
 Documentation=https://github.com/openshift/origin
 
 [Service]

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -5,9 +5,6 @@
 - name: Set hostname to IP Addr (WORKAROUND)
   hostname: name={{ oo_bind_ip }}
 
-- name: Install docker
-  yum: pkg=docker state=installed
-
 - include: openshift_from_yum.yml
   when: oo_openshift_binary is not defined
 

--- a/roles/openshift_minion/tasks/main.yml
+++ b/roles/openshift_minion/tasks/main.yml
@@ -5,9 +5,6 @@
 - name: Set hostname to IP Addr (WORKAROUND)
   hostname: name={{ oo_bind_ip }}
 
-- name: Install docker
-  yum: pkg=docker state=installed
-
 - include: openshift_from_yum.yml
   when: oo_openshift_binary is not defined
 


### PR DESCRIPTION
The AWS region, AMI, keypair and instance type are not hardcoded anymore.
They can be customized in the config file.
If the config file is empty, the default values are the previous hardcoded ones.